### PR TITLE
Pin twine back to 5.0.0 to avoid yanked version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         "dtaidistance",
         "gdown",
         "pandas",
+        "twine==5.0.0"
     ],
     extras_require={"dev": ["build", "mypy", "pre-commit", "pytest"]},
 )


### PR DESCRIPTION
Twine 5.1.0 is broken.
cf. https://pypi.org/project/twine/#history and 
https://github.com/pypa/twine/pull/1127